### PR TITLE
Add strict null check in resetAlerts

### DIFF
--- a/index.html
+++ b/index.html
@@ -993,8 +993,12 @@
         }).format(date);
 
       const resetAlerts = (...elements) => {
-        elements.forEach((el) => {
-          if (!el) return;
+        elements.forEach((el, idx) => {
+          if (!el) {
+            throw new Error(
+              `resetAlerts: element at index ${idx} is null or undefined`,
+            );
+          }
           el.classList.add("hidden");
           el.textContent = "";
         });


### PR DESCRIPTION
## Summary
- throw an explicit error when resetAlerts receives a null or undefined element

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d45bb0f2e48325b6c7237ca79ca218