### PR TITLE
Add activity management sections for admin and auxiliary roles

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,6 +182,67 @@
                   <div id="userTableContainer"></div>
                 </div>
               </div>
+              <div class="card">
+                <h2>Gestión de Actividades</h2>
+                <p class="card-subtitle">
+                  Registra tareas clave y da seguimiento al avance del equipo.
+                </p>
+                <form id="adminActivityForm">
+                  <div class="grid activity-form-grid">
+                    <div class="form-field">
+                      <label for="activityTitle">Título de la actividad</label>
+                      <input
+                        id="activityTitle"
+                        name="title"
+                        type="text"
+                        required
+                        placeholder="Ej. Seguimiento de planeaciones"
+                      />
+                    </div>
+                    <div class="form-field">
+                      <label for="activityDueDate">Fecha límite</label>
+                      <input
+                        id="activityDueDate"
+                        name="dueDate"
+                        type="date"
+                        required
+                      />
+                    </div>
+                    <div class="form-field" style="grid-column: 1 / -1">
+                      <label for="activityDescription">Descripción</label>
+                      <textarea
+                        id="activityDescription"
+                        name="description"
+                        rows="3"
+                        placeholder="Describe el objetivo y entregables de la actividad"
+                      ></textarea>
+                    </div>
+                    <div class="form-field">
+                      <label for="activityRole">Responsable</label>
+                      <select id="activityRole" name="responsibleRole" required>
+                        <option value="docente">Docente</option>
+                        <option value="auxiliar">Profesor auxiliar</option>
+                        <option value="administrador">Administrador</option>
+                      </select>
+                    </div>
+                    <div class="form-field">
+                      <label for="activityEmail">Correo del responsable (opcional)</label>
+                      <input
+                        id="activityEmail"
+                        name="responsibleEmail"
+                        type="email"
+                        placeholder="persona@potros.itson.edu.mx"
+                      />
+                    </div>
+                  </div>
+                  <button class="primary" type="submit">
+                    <i data-lucide="plus"></i>
+                    <span>Registrar actividad</span>
+                  </button>
+                </form>
+                <div id="adminActivityAlert"></div>
+                <div id="adminActivityList" class="activity-table"></div>
+              </div>
             </div>
 
             <!-- Vistas de Docente -->
@@ -196,7 +257,21 @@
             <div id="auxiliarView" class="hidden">
               <div class="card">
                 <h2>Actividades de Apoyo</h2>
-                <div id="assistantActivities" style="margin-top: 1.25rem"></div>
+                <p class="card-subtitle">
+                  Consulta tus tareas asignadas y actualiza su estado para
+                  mantener informado al equipo.
+                </p>
+                <div class="activity-legend">
+                  <span class="status-badge status-pendiente">Pendiente</span>
+                  <span class="status-badge status-en_progreso">En progreso</span>
+                  <span class="status-badge status-completada">Completada</span>
+                </div>
+                <div id="auxiliarActivityAlert"></div>
+                <div
+                  id="auxiliarActivityList"
+                  class="activity-cards"
+                  style="margin-top: 1.25rem"
+                ></div>
               </div>
             </div>
           </section>

--- a/style.css
+++ b/style.css
@@ -187,6 +187,11 @@ main {
   font-weight: 600;
   letter-spacing: -0.02em;
 }
+.card-subtitle {
+  margin: 0.35rem 0 1.5rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
 form {
   display: flex;
   flex-direction: column;
@@ -340,6 +345,9 @@ nav button.active {
   gap: 1.75rem;
   align-content: start;
 }
+.activity-form-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
 .grid {
   display: grid;
   gap: 1rem;
@@ -400,6 +408,96 @@ td small {
   border-radius: 18px;
   border: 1px dashed rgba(42, 157, 143, 0.25);
   color: var(--muted);
+}
+.activity-table {
+  margin-top: 2rem;
+}
+.activity-legend {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 1.25rem;
+}
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+.status-badge.status-pendiente {
+  background: rgba(233, 196, 106, 0.18);
+  color: #c68c1d;
+}
+.status-badge.status-en_progreso {
+  background: rgba(42, 157, 143, 0.16);
+  color: var(--primary);
+}
+.status-badge.status-completada {
+  background: rgba(43, 147, 72, 0.18);
+  color: var(--success);
+}
+.activity-cards {
+  display: grid;
+  gap: 1rem;
+}
+.activity-card {
+  border: 1px solid rgba(42, 157, 143, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  padding: 1.25rem 1.5rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 22px 45px -38px rgba(38, 70, 83, 0.45);
+}
+.activity-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
+}
+.activity-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.activity-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+.activity-meta span {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+.activity-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+.activity-actions label {
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+.activity-actions select {
+  min-width: 160px;
+}
+.activity-status-cell {
+  display: grid;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+.activity-status-select {
+  width: 100%;
 }
 .action-buttons {
   display: flex;


### PR DESCRIPTION
## Summary
- add an activity management card for administrators with a registration form and activity table
- create a support-activity view for auxiliary staff with dynamic status badges and filters
- implement Firestore listeners and handlers to create, update and delete activities plus new styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d57c88e57483258319e8e46b99fc88