### PR TITLE
Agregar columnas de perfil docente a la tabla de usuarios

### DIFF
--- a/script.js
+++ b/script.js
@@ -327,6 +327,11 @@ const escapeHTML = (value = "") =>
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
 
+const formatProfileValue = (value) =>
+  value && value.toString().trim()
+    ? escapeHTML(value)
+    : '<span class="table-placeholder">Sin registro</span>';
+
 const formatDueDate = (value) => {
   if (!value) return "Sin fecha";
   const date = new Date(value);
@@ -526,7 +531,19 @@ const renderUserTable = () => {
     }
     let tableHTML = `
       <table>
-        <thead><tr><th>Nombre</th><th>Carrera</th><th>Rol</th><th>Acciones</th></tr></thead>
+        <thead>
+          <tr>
+            <th>Nombre</th>
+            <th>ID</th>
+            <th>Número de Control</th>
+            <th>Correo Potro</th>
+            <th>Correo Institucional</th>
+            <th>Celular</th>
+            <th>Carrera</th>
+            <th>Rol</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
         <tbody>
     `;
     snapshot.docs.forEach((docSnap) => {
@@ -543,12 +560,25 @@ const renderUserTable = () => {
       const roleLabel = escapeHTML(
         ROLE_LABELS[roleKey] || roleKey || "Rol no especificado"
       );
+      const teacherProfile = user.teacherProfile || {};
+      const employeeId = formatProfileValue(teacherProfile.employeeId);
+      const controlNumber = formatProfileValue(teacherProfile.controlNumber);
+      const potroEmail = formatProfileValue(teacherProfile.potroEmail);
+      const institutionalEmail = formatProfileValue(
+        teacherProfile.institutionalEmail
+      );
+      const phone = formatProfileValue(teacherProfile.phone);
 
       tableHTML += `
         <tr>
           <td>${displayName}${
         email ? `<br><small>${email}</small>` : "<br><small>Sin correo registrado</small>"
       }</td>
+          <td>${employeeId}</td>
+          <td>${controlNumber}</td>
+          <td>${potroEmail}</td>
+          <td>${institutionalEmail}</td>
+          <td>${phone}</td>
           <td>${careerLabel}</td>
           <td><span class="${roleBadgeClass}">${roleLabel}</span></td>
           <td>

--- a/style.css
+++ b/style.css
@@ -391,6 +391,10 @@ td small {
   color: var(--muted);
   font-size: 0.85rem;
 }
+.table-placeholder {
+  color: var(--muted);
+  font-style: italic;
+}
 .badge {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- mostrar los campos de perfil docente (ID, número de control, correos y celular) en la tabla de administración
- añadir un formateador reutilizable para presentar los datos del perfil o un marcador cuando falten valores
- ajustar los estilos para los marcadores de datos ausentes en la tabla

## Testing
- no se ejecutaron pruebas (no aplicable)


------
https://chatgpt.com/codex/tasks/task_e_68d59db703888325943f3d38fb74ee63