### PR TITLE
Reduce header height and remove header stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,14 +38,6 @@
           </div>
         </div>
         <div class="header-tools">
-          <div class="header-stat">
-            <span class="label">Actividades activas</span>
-            <span class="value" id="headerActiveTasks">—</span>
-          </div>
-          <div class="header-stat">
-            <span class="label">Usuarios conectados</span>
-            <span class="value" id="headerActiveUsers">—</span>
-          </div>
           <div class="user-meta hidden" id="headerUserMeta">
             <span id="headerUserName"></span>
             <span class="badge" id="headerUserRole"></span>

--- a/style.css
+++ b/style.css
@@ -45,7 +45,7 @@ a {
   background: linear-gradient(110deg, rgba(37, 99, 235, 0.9), rgba(30, 64, 175, 0.85));
   color: white;
 
-  padding: clamp(1rem, 1.4vw + 0.8rem, 1.75rem) 0;
+  padding: clamp(0.65rem, 1vw + 0.6rem, 1.25rem) 0;
 
   box-shadow: 0 24px 50px -40px rgba(30, 64, 175, 0.6);
   backdrop-filter: blur(18px);
@@ -62,7 +62,7 @@ main {
   display: flex;
   align-items: flex-start;
 
-  gap: clamp(0.85rem, 2.5vw, 2rem);
+  gap: clamp(0.65rem, 2vw, 1.5rem);
 
 }
 
@@ -141,33 +141,11 @@ main {
 }
 
 .header-tools {
-  margin-top: clamp(0.9rem, 1.6vw, 1.4rem);
+  margin-top: clamp(0.5rem, 1.2vw, 1rem);
   display: flex;
   align-items: center;
   gap: 1.25rem;
   flex-wrap: wrap;
-}
-
-.header-stat {
-  background: rgba(15, 23, 42, 0.25);
-  border-radius: 18px;
-  padding: 0.65rem 1rem;
-
-  display: grid;
-  gap: 0.3rem;
-  min-width: 150px;
-}
-
-.header-stat .label {
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.65);
-}
-
-.header-stat .value {
-  font-size: 1.35rem;
-  font-weight: 600;
 }
 
 header .user-meta {


### PR DESCRIPTION
## Summary
- shrink the app header padding and spacing to reduce its height
- remove the "Actividades activas" and "Usuarios conectados" blocks from the header
- clean up unused header statistic styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c002454c832597d9f90b185e43d0