### PR TITLE
Remove header highlights and tighten header spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,32 +47,6 @@
           </div>
         </div>
       </div>
-      <div class="app-header__meta">
-        <div class="meta-highlight">
-          <i data-lucide="target"></i>
-          <div>
-            <span>Visión general</span>
-            <p>Obtén indicadores clave en segundos y coordina a tu equipo con
-              claridad.</p>
-          </div>
-        </div>
-        <div class="meta-highlight">
-          <i data-lucide="calendar-check"></i>
-          <div>
-            <span>Seguimiento de actividades</span>
-            <p>Consulta avances, responsables y fechas límite desde un tablero
-              flexible.</p>
-          </div>
-        </div>
-        <div class="meta-highlight">
-          <i data-lucide="file-spreadsheet"></i>
-          <div>
-            <span>Reportes listos</span>
-            <p>Genera reportes por carrera y rol para respaldar decisiones
-              académicas.</p>
-          </div>
-        </div>
-      </div>
     </header>
 
     <main>

--- a/style.css
+++ b/style.css
@@ -38,20 +38,20 @@ a {
 }
 
 /* Header */
+
 .app-header {
   position: static;
   z-index: 20;
   background: linear-gradient(110deg, rgba(37, 99, 235, 0.9), rgba(30, 64, 175, 0.85));
   color: white;
 
-  padding: clamp(0.65rem, 1vw + 0.6rem, 1.25rem) 0;
+  padding: clamp(0.45rem, 0.8vw + 0.35rem, 0.9rem) 0;
 
   box-shadow: 0 24px 50px -40px rgba(30, 64, 175, 0.6);
   backdrop-filter: blur(18px);
 }
 
 .app-header__inner,
-.app-header__meta,
 main {
   width: min(1400px, 96vw);
   margin: 0 auto;
@@ -194,42 +194,6 @@ nav ul {
 header button:hover {
   transform: translateY(-1px);
   box-shadow: 0 18px 35px -18px rgba(15, 23, 42, 0.65);
-}
-
-.app-header__meta {
-  margin-top: clamp(1.35rem, 2.5vw, 2.1rem);
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-  gap: 0.9rem;
-}
-
-.meta-highlight {
-  display: flex;
-  gap: 0.75rem;
-  align-items: flex-start;
-  padding: 0.85rem 1.15rem;
-  border-radius: 18px;
-  background: rgba(15, 23, 42, 0.25);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-}
-
-.meta-highlight i {
-  width: 1.6rem;
-  height: 1.6rem;
-}
-
-.meta-highlight span {
-  font-size: 0.9rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.meta-highlight p {
-  margin: 0.4rem 0 0;
-  font-size: 0.92rem;
-  color: rgba(255, 255, 255, 0.82);
-  line-height: 1.5;
 }
 
 /* Main layout */


### PR DESCRIPTION
## Summary
- remove the meta highlight section from the header to simplify the hero area
- shrink the header padding to reduce its overall height and clean up unused styles

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5c21d36b48325910ae88993c5db95