### PR TITLE
Ajusta layout principal a altura de pantalla

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,6 +31,32 @@ const STATUS_COLORS = {
   completada: "#10b981",
 };
 
+let resizeFrame = null;
+
+function syncHeaderHeight() {
+  const header = document.querySelector(".app-header");
+  const headerHeight = header ? header.offsetHeight : 0;
+  document.documentElement.style.setProperty(
+    "--header-height",
+    `${headerHeight}px`,
+  );
+}
+
+function scheduleHeaderSync() {
+  if (resizeFrame) cancelAnimationFrame(resizeFrame);
+  resizeFrame = requestAnimationFrame(syncHeaderHeight);
+}
+
+function updateLayoutMode() {
+  const body = document.body;
+  const dashboardVisible =
+    currentUser !== null &&
+    elements.dashboard &&
+    !elements.dashboard.classList.contains("hidden");
+  body.classList.toggle("dashboard-active", dashboardVisible);
+  body.classList.toggle("auth-active", !dashboardVisible);
+}
+
 const initialUsers = [
   {
     id: "u-admin-1",
@@ -224,6 +250,10 @@ const elements = {};
 
 document.addEventListener("DOMContentLoaded", () => {
   cacheDomElements();
+  updateLayoutMode();
+  scheduleHeaderSync();
+  window.addEventListener("resize", scheduleHeaderSync);
+  window.addEventListener("orientationchange", scheduleHeaderSync);
   hideLoader();
   populateUserSelector(elements.userSelector);
   attachEventListeners();
@@ -356,6 +386,8 @@ function loginUser(user) {
   if (elements.authSection) elements.authSection.classList.add("hidden");
   if (elements.dashboard) elements.dashboard.classList.remove("hidden");
   if (elements.headerUserMeta) elements.headerUserMeta.classList.remove("hidden");
+  updateLayoutMode();
+  scheduleHeaderSync();
 
   if (elements.headerUserName) elements.headerUserName.textContent = user.name;
   if (elements.headerUserRole) {
@@ -377,6 +409,8 @@ function handleLogout() {
   if (elements.dashboard) elements.dashboard.classList.add("hidden");
   if (elements.authSection) elements.authSection.classList.remove("hidden");
   if (elements.headerUserMeta) elements.headerUserMeta.classList.add("hidden");
+  updateLayoutMode();
+  scheduleHeaderSync();
   if (elements.headerUserName) elements.headerUserName.textContent = "";
   if (elements.headerUserRole) {
     elements.headerUserRole.textContent = "";

--- a/style.css
+++ b/style.css
@@ -11,6 +11,7 @@
   --success: #10b981;
   --warning: #facc15;
   --danger: #ef4444;
+  --header-height: 0px;
   font-family: "Montserrat", system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
   background-color: var(--bg);
@@ -24,6 +25,9 @@
 body {
   margin: 0;
   min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
   background: radial-gradient(circle at top, rgba(37, 99, 235, 0.12), transparent
         55%),
     linear-gradient(180deg, #ffffff 0%, var(--bg) 50%, #eef2ff 100%);
@@ -198,13 +202,34 @@ header button:hover {
 
 /* Main layout */
 main {
-  padding: clamp(2rem, 4vw, 3.5rem) 0 4rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: clamp(2rem, 4vw, 3rem);
+  padding: clamp(2rem, 4vw, 3.5rem) 0 clamp(2rem, 4vw, 3.5rem);
+  min-height: calc(100vh - var(--header-height));
+  min-height: calc(100dvh - var(--header-height));
+}
+
+main > section {
+  flex: 1 0 auto;
+  width: 100%;
+}
+
+body.dashboard-active main {
+  justify-content: flex-start;
+}
+
+body.auth-active main {
+  justify-content: center;
 }
 
 /* Auth */
 #authSection {
   display: flex;
   justify-content: center;
+  align-items: center;
+  flex: 1;
 }
 
 .auth-layout {


### PR DESCRIPTION
## Summary
- Ajusta el contenedor principal para ocupar la altura visible, centrar la autenticación y eliminar el desplazamiento vertical en la vista inicial.
- Sincroniza vía JavaScript la altura del encabezado y alterna clases en el cuerpo para adaptar el layout al iniciar o cerrar sesión.

## Testing
- Manual frontend test on browser (see attached screenshot).


------
https://chatgpt.com/codex/tasks/task_e_68d5c370ac808325ba103b14b9cdb25c