### PR TITLE
Ajusta layout de inicio de sesión a altura de pantalla

### DIFF
--- a/style.css
+++ b/style.css
@@ -205,8 +205,8 @@ main {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: clamp(2rem, 4vw, 3rem);
-  padding: clamp(2rem, 4vw, 3.5rem) 0 clamp(2rem, 4vw, 3.5rem);
+  gap: clamp(1.75rem, 3vw, 3rem);
+  padding: clamp(1.25rem, 3vh, 3.5rem) 0 clamp(1.25rem, 3vh, 3.5rem);
   min-height: calc(100vh - var(--header-height));
   min-height: calc(100dvh - var(--header-height));
 }
@@ -235,19 +235,19 @@ body.auth-active main {
 .auth-layout {
   display: grid;
   grid-template-columns: minmax(280px, 1.1fr) minmax(320px, 1fr);
-  gap: clamp(1.5rem, 4vw, 3rem);
+  gap: clamp(1.25rem, 3vw, 3rem);
   align-items: stretch;
 }
 
 .auth-hero {
   position: relative;
   border-radius: 32px;
-  padding: clamp(1.8rem, 4vw, 3rem);
+  padding: clamp(1.5rem, 3vh, 3rem);
   background: linear-gradient(155deg, rgba(37, 99, 235, 0.95), rgba(14, 116, 144, 0.88));
   color: white;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: clamp(1.1rem, 2.4vh, 1.6rem);
   overflow: hidden;
   box-shadow: 0 40px 90px -50px rgba(15, 23, 42, 0.65);
 }
@@ -316,7 +316,7 @@ body.auth-active main {
 .auth-metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 1rem;
+  gap: clamp(0.75rem, 1.8vh, 1rem);
   margin-top: auto;
 }
 
@@ -341,13 +341,13 @@ body.auth-active main {
 
 .auth-panel {
   display: grid;
-  gap: 1.5rem;
+  gap: clamp(1.1rem, 2.6vh, 1.6rem);
 }
 
 .card {
   background: var(--surface);
   border-radius: 26px;
-  padding: clamp(1.5rem, 3vw, 2.25rem);
+  padding: clamp(1.25rem, 3vw, 2.25rem);
   box-shadow: 0 35px 80px -50px rgba(15, 23, 42, 0.35);
   border: 1px solid rgba(37, 99, 235, 0.08);
   min-width: 0;
@@ -1209,6 +1209,53 @@ button.small i {
   button.ghost {
     width: 100%;
     justify-content: center;
+  }
+}
+
+@media (max-height: 820px) {
+  body.auth-active main {
+    gap: clamp(1rem, 2vh, 2.4rem);
+  }
+
+  body.auth-active .auth-hero {
+    padding: clamp(1.25rem, 2.6vh, 2.4rem);
+    gap: clamp(0.95rem, 2vh, 1.35rem);
+  }
+
+  body.auth-active .auth-hero h2 {
+    font-size: clamp(1.65rem, 4.8vh, 2.3rem);
+  }
+
+  body.auth-active .auth-hero p,
+  body.auth-active .auth-support p {
+    font-size: 0.95rem;
+  }
+
+  body.auth-active .auth-panel {
+    gap: clamp(0.9rem, 2vh, 1.35rem);
+  }
+
+  body.auth-active .card {
+    padding: clamp(1.05rem, 2.4vh, 1.8rem);
+  }
+
+  body.auth-active .auth-support {
+    padding: clamp(1.1rem, 2.4vh, 1.5rem) clamp(1.1rem, 2.4vh, 1.6rem);
+    gap: clamp(0.75rem, 1.6vh, 1rem);
+  }
+}
+
+@media (max-height: 700px) {
+  body.auth-active .auth-layout {
+    gap: clamp(0.9rem, 2vw, 1.5rem);
+  }
+
+  body.auth-active .auth-metrics {
+    display: none;
+  }
+
+  body.auth-active .auth-support {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- reduce los márgenes verticales del main y el panel de autenticación para acomodar la vista en alturas menores
- adapta paddings y separación de la sección de héroe y el card de acceso usando unidades relativas al alto de la ventana
- agrega consultas por altura que compactan tipografías y ocultan bloques secundarios en pantallas muy bajas

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5c5c092708325b00ae68c7146a5ca