### PR TITLE
Fix main layout height to 700px

### DIFF
--- a/style.css
+++ b/style.css
@@ -207,8 +207,10 @@ main {
   justify-content: center;
   gap: clamp(1.75rem, 3vw, 3rem);
   padding: clamp(1.25rem, 3vh, 3.5rem) 0 clamp(1.25rem, 3vh, 3.5rem);
-  min-height: calc(100vh - var(--header-height));
-  min-height: calc(100dvh - var(--header-height));
+  height: 700px;
+  min-height: 700px;
+  max-height: 700px;
+  overflow-y: auto;
 }
 
 main > section {
@@ -222,6 +224,16 @@ body.dashboard-active main {
 
 body.auth-active main {
   justify-content: center;
+}
+
+@media (max-height: 760px) {
+  main {
+    height: auto;
+    min-height: calc(100vh - var(--header-height));
+    min-height: calc(100dvh - var(--header-height));
+    max-height: none;
+    overflow-y: visible;
+  }
 }
 
 /* Auth */


### PR DESCRIPTION
## Summary
- set the main container to a fixed 700px height with scrollable overflow so the change is visible in the UI
- add a safety media query to restore the flexible height on short viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c792667883259c546627208926b0