### PR TITLE
Ajustar layout a la ventana sin scroll vertical

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,6 +31,7 @@ body {
   background: radial-gradient(circle at top, rgba(37, 99, 235, 0.12), transparent
         55%),
     linear-gradient(180deg, #ffffff 0%, var(--bg) 50%, #eef2ff 100%);
+  overflow: hidden;
 }
 
 .hidden {
@@ -76,46 +77,6 @@ main {
 
   display: flex;
   justify-content: center;
-}
-
-.auth-layout {
-  display: grid;
-  grid-template-columns: minmax(280px, 1.1fr) minmax(320px, 1fr);
-  gap: clamp(1.5rem, 4vw, 3rem);
-  align-items: stretch;
-}
-
-.auth-hero {
-  position: relative;
-  border-radius: 32px;
-  padding: clamp(1.8rem, 4vw, 3rem);
-  background: linear-gradient(155deg, rgba(37, 99, 235, 0.95), rgba(14, 116, 144, 0.88));
-  color: white;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  overflow: hidden;
-  box-shadow: 0 40px 90px -50px rgba(15, 23, 42, 0.65);
-}
-
-.auth-hero::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at top right, rgba(250, 204, 21, 0.35), transparent 55%);
-  pointer-events: none;
-}
-
-.auth-hero > * {
-  position: relative;
-  z-index: 1;
-}
-
-.eyebrow {
-  display: inline-flex;
-  align-items: center;
-
-  gap: 0.65rem;
 }
 
 .brand-area h1 i {
@@ -205,19 +166,20 @@ main {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  gap: clamp(1.75rem, 3vw, 3rem);
-  padding: clamp(1.25rem, 3vh, 3.5rem) 0 clamp(1.25rem, 3vh, 3.5rem);
-
-  height: 700px;
-  min-height: 700px;
-  max-height: 700px;
-  overflow-y: auto;
-
+  gap: clamp(1.25rem, 2.5vh, 2.5rem);
+  padding: clamp(1rem, 2.4vh, 3rem) 0 clamp(1rem, 2.4vh, 3rem);
+  flex: 1 1 auto;
+  min-height: calc(100dvh - var(--header-height));
+  max-height: calc(100dvh - var(--header-height));
+  overflow: hidden;
 }
 
 main > section {
-  flex: 1 0 auto;
+  flex: 1 1 auto;
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 body.dashboard-active main {
@@ -229,12 +191,30 @@ body.auth-active main {
 }
 
 @media (max-height: 760px) {
+  .app-header {
+    padding: clamp(0.35rem, 1vh, 0.75rem) 0;
+  }
+
   main {
-    height: auto;
-    min-height: calc(100vh - var(--header-height));
-    min-height: calc(100dvh - var(--header-height));
-    max-height: none;
-    overflow-y: visible;
+    gap: clamp(0.75rem, 1.5vh, 1.4rem);
+    padding: clamp(0.75rem, 1.5vh, 1.5rem) 0 clamp(0.75rem, 1.5vh, 1.5rem);
+  }
+
+  .auth-hero {
+    padding: clamp(1rem, 1.8vh, 1.5rem);
+    gap: clamp(0.65rem, 1.4vh, 1rem);
+  }
+
+  .auth-hero h2 {
+    font-size: clamp(1.5rem, 3.2vh, 1.95rem);
+  }
+
+  .auth-panel {
+    gap: clamp(0.65rem, 1.5vh, 1rem);
+  }
+
+  .auth-support {
+    padding: 1.25rem 1.4rem;
   }
 }
 
@@ -249,19 +229,25 @@ body.auth-active main {
 .auth-layout {
   display: grid;
   grid-template-columns: minmax(280px, 1.1fr) minmax(320px, 1fr);
-  gap: clamp(1.25rem, 3vw, 3rem);
+  gap: clamp(1.1rem, 2.5vw, 2.5rem);
   align-items: stretch;
+  height: 100%;
+  min-height: 0;
+}
+
+.auth-layout > * {
+  min-height: 0;
 }
 
 .auth-hero {
   position: relative;
   border-radius: 32px;
-  padding: clamp(1.5rem, 3vh, 3rem);
+  padding: clamp(1.25rem, 2.6vh, 2.5rem);
   background: linear-gradient(155deg, rgba(37, 99, 235, 0.95), rgba(14, 116, 144, 0.88));
   color: white;
   display: flex;
   flex-direction: column;
-  gap: clamp(1.1rem, 2.4vh, 1.6rem);
+  gap: clamp(0.9rem, 2vh, 1.4rem);
   overflow: hidden;
   box-shadow: 0 40px 90px -50px rgba(15, 23, 42, 0.65);
 }
@@ -355,7 +341,9 @@ body.auth-active main {
 
 .auth-panel {
   display: grid;
-  gap: clamp(1.1rem, 2.6vh, 1.6rem);
+  gap: clamp(0.9rem, 2.2vh, 1.4rem);
+  height: 100%;
+  align-content: start;
 }
 
 .card {
@@ -507,12 +495,31 @@ button.primary:hover {
   gap: 0.65rem;
 }
 
+#loginCard {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+#loginCard form {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+#loginCard .form-actions {
+  margin-top: auto;
+}
+
 /* Dashboard layout */
 .dashboard-shell {
   display: grid;
   grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
   gap: clamp(1.8rem, 3vw, 2.4rem);
-  align-items: start;
+  align-items: stretch;
+  height: 100%;
+  min-height: 0;
 }
 
 .sidebar {
@@ -521,6 +528,8 @@ button.primary:hover {
   padding: 2rem 1.75rem;
   display: flex;
   flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
   gap: 2rem;
   color: white;
   box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.55);
@@ -613,6 +622,9 @@ nav button.active {
   gap: 2rem;
   align-content: start;
   min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.25rem;
 }
 
 .content-intro {


### PR DESCRIPTION
## Resumen
- fijé el alto del contenedor principal al viewport y deshabilité el scroll vertical del body para que el tablero siempre llene la ventana
- ajusté la rejilla de autenticación, el panel de inicio de sesión y los estilos responsivos para que sus contenidos se distribuyan dentro de la altura disponible
- habilité scroll interno en la barra lateral y el área principal del tablero para mantener el acceso al contenido cuando el dashboard está activo

## Pruebas
- no se requirieron pruebas automatizadas


------
https://chatgpt.com/codex/tasks/task_e_68d5cd4dde048325b547fdd0d72bc629