### PR TITLE
Adjust auth layout vertical positioning

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,7 +31,7 @@ body {
   background: radial-gradient(circle at top, rgba(37, 99, 235, 0.12), transparent
         55%),
     linear-gradient(180deg, #ffffff 0%, var(--bg) 50%, #eef2ff 100%);
-  overflow: hidden;
+  overflow-x: hidden;
 }
 
 .hidden {
@@ -170,8 +170,8 @@ main {
   padding: clamp(1rem, 2.4vh, 3rem) 0 clamp(1rem, 2.4vh, 3rem);
   flex: 1 1 auto;
   min-height: calc(100dvh - var(--header-height));
-  max-height: calc(100dvh - var(--header-height));
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 main > section {
@@ -187,7 +187,7 @@ body.dashboard-active main {
 }
 
 body.auth-active main {
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 @media (max-height: 760px) {


### PR DESCRIPTION
## Summary
- allow the body to scroll vertically by removing the global overflow lock and keeping horizontal overflow hidden
- update the main container alignment so the authentication panel starts higher on the screen for better visibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6b679a7ac83258405fc732a8dbd10