### PR TITLE
Adjust auth support card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,17 +117,63 @@
               <div class="alert error" id="loginError"></div>
             </div>
             <div class="auth-support">
-              <div>
-                <i data-lucide="headset"></i>
-                <h3>¿Necesitas ayuda?</h3>
-                <p>
-                  Nuestro equipo académico puede orientarte con la migración de
-                  datos o la incorporación de nuevos usuarios.
-                </p>
+              <div class="auth-support__intro">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M3 11h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-5Zm0 0a9 9 0 1 1 18 0m0 0v5a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3Z"
+                  ></path>
+                  <path d="M21 16v2a4 4 0 0 1-4 4h-5"></path>
+                </svg>
+                <div>
+                  <h3>¿Necesitas ayuda?</h3>
+                  <p>
+                    Nuestro equipo académico puede orientarte con la migración
+                    de datos o la incorporación de nuevos usuarios.
+                  </p>
+                </div>
               </div>
               <ul>
-                <li><i data-lucide="mail"></i> soporte@itson.edu.mx</li>
-                <li><i data-lucide="phone"></i> (644) 410 9000 ext. 125</li>
+                <li>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path
+                      d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7"
+                    ></path>
+                    <rect x="2" y="4" width="20" height="16" rx="2"></rect>
+                  </svg>
+                  soporte@itson.edu.mx
+                </li>
+                <li>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path
+                      d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"
+                    ></path>
+                  </svg>
+                  (644) 410 9000 ext. 125
+                </li>
               </ul>
             </div>
           </div>

--- a/style.css
+++ b/style.css
@@ -461,22 +461,41 @@ button.primary:hover {
 
 .auth-support {
   background: var(--surface);
-  border-radius: 22px;
-  padding: 1.5rem 1.75rem;
-  border: 1px dashed rgba(37, 99, 235, 0.2);
+  border-radius: 20px;
+  padding: 1.2rem 1.4rem;
+  border: 1px dashed rgba(37, 99, 235, 0.18);
   display: grid;
-  gap: 1.1rem;
-  box-shadow: 0 25px 70px -55px rgba(15, 23, 42, 0.35);
+  gap: 0.9rem;
+  box-shadow: 0 22px 60px -55px rgba(15, 23, 42, 0.35);
+  align-self: flex-start;
+}
+
+.auth-support__intro {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.auth-support__intro > svg {
+  width: 22px;
+  height: 22px;
+  padding: 0.35rem;
+  border-radius: 12px;
+  background: var(--surface-alt);
+  color: var(--primary);
+  flex-shrink: 0;
 }
 
 .auth-support h3 {
-  margin: 0.4rem 0 0.25rem;
+  margin: 0 0 0.2rem;
+  font-size: 1.05rem;
 }
 
 .auth-support p {
   margin: 0;
   color: var(--muted);
   line-height: 1.5;
+  font-size: 0.92rem;
 }
 
 .auth-support ul {
@@ -484,15 +503,23 @@ button.primary:hover {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.5rem;
+  gap: 0.45rem;
   color: var(--text);
   font-weight: 500;
+  font-size: 0.95rem;
 }
 
 .auth-support li {
   display: flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.5rem;
+}
+
+.auth-support li svg {
+  width: 18px;
+  height: 18px;
+  color: var(--primary);
+  flex-shrink: 0;
 }
 
 #loginCard {


### PR DESCRIPTION
## Summary
- rework the "¿Necesitas ayuda?" support card with inline SVG icons and a compact header layout
- tighten spacing, typography, and icon sizing so the support card aligns visually with the auth hero section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6b9af0bd083258a1b89f4ee5fb0b2