### PR TITLE
Reduce app header height

### DIFF
--- a/style.css
+++ b/style.css
@@ -50,7 +50,7 @@ a {
   background: linear-gradient(110deg, rgba(37, 99, 235, 0.9), rgba(30, 64, 175, 0.85));
   color: white;
 
-  padding: clamp(0.36rem, 0.64vw + 0.28rem, 0.72rem) 0;
+  padding: clamp(0.24rem, 0.5vw + 0.18rem, 0.58rem) 0;
 
   box-shadow: 0 24px 50px -40px rgba(30, 64, 175, 0.6);
   backdrop-filter: blur(18px);
@@ -105,7 +105,7 @@ main {
 }
 
 .header-tools {
-  margin-top: clamp(0.5rem, 1.2vw, 1rem);
+  margin-top: clamp(0.35rem, 1vw, 0.85rem);
   display: flex;
   align-items: center;
   gap: 1.25rem;


### PR DESCRIPTION
## Summary
- shrink the vertical padding of the app header to lower its visual height
- tighten spacing above header tools for a more compact layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c94350748325b97cd0054490b95e