### PR TITLE
Mueve el bloque de usuario al borde derecho del encabezado

### DIFF
--- a/style.css
+++ b/style.css
@@ -62,6 +62,13 @@ main {
   margin: 0 auto;
 }
 
+.app-header__inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: clamp(1rem, 3vw, 2.5rem);
+}
+
 .brand-area {
   display: flex;
   align-items: flex-start;
@@ -107,7 +114,7 @@ main {
 .header-tools {
   margin-top: clamp(0.35rem, 1vw, 0.85rem);
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 1.25rem;
   flex-wrap: wrap;
 }


### PR DESCRIPTION
## Resumen
- convierte el contenedor interior del encabezado en un flex layout para separar la marca y los metadatos de usuario
- ajusta la alineación de la sección de herramientas del encabezado para que el bloque de usuario se ancle en la esquina superior derecha tras iniciar sesión

## Pruebas
- no se requirieron pruebas automatizadas

------
https://chatgpt.com/codex/tasks/task_e_68d6cb3c9d248325a952cb0901460523