### PR TITLE
Implement sidebar toggle and adjust dashboard layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,8 +166,18 @@
 
       <!-- Dashboard Principal -->
       <section id="dashboard" class="hidden">
-        <div class="dashboard-shell">
+        <div class="dashboard-shell" id="dashboardShell">
           <aside class="sidebar">
+            <button
+              type="button"
+              class="sidebar-toggle"
+              id="sidebarCollapseBtn"
+              aria-label="Ocultar menú lateral"
+              aria-expanded="true"
+            >
+              <i data-lucide="panel-left-close"></i>
+              <span>Ocultar menú</span>
+            </button>
             <div class="user-card">
               <span class="user-badge">Sesión activa</span>
               <h3 id="sidebarName"></h3>
@@ -188,6 +198,16 @@
             </div>
           </aside>
           <section class="content-area">
+            <button
+              type="button"
+              class="sidebar-toggle sidebar-toggle--floating"
+              id="sidebarExpandBtn"
+              aria-label="Mostrar menú lateral"
+              hidden
+            >
+              <i data-lucide="panel-left"></i>
+              <span>Mostrar menú</span>
+            </button>
             <div
               class="content-intro"
               id="dashboardIntro"

--- a/script.js
+++ b/script.js
@@ -57,6 +57,30 @@ function updateLayoutMode() {
   body.classList.toggle("auth-active", !dashboardVisible);
 }
 
+function setSidebarCollapsed(value) {
+  if (!elements.dashboardShell) return;
+  const shouldCollapse =
+    typeof value === "boolean"
+      ? value
+      : !elements.dashboardShell.classList.contains("sidebar-collapsed");
+  elements.dashboardShell.classList.toggle("sidebar-collapsed", shouldCollapse);
+  if (elements.sidebarCollapseBtn) {
+    elements.sidebarCollapseBtn.setAttribute(
+      "aria-expanded",
+      String(!shouldCollapse),
+    );
+  }
+  if (elements.sidebarExpandBtn) {
+    if (shouldCollapse) {
+      elements.sidebarExpandBtn.removeAttribute("hidden");
+      elements.sidebarExpandBtn.setAttribute("aria-hidden", "false");
+    } else {
+      elements.sidebarExpandBtn.setAttribute("hidden", "hidden");
+      elements.sidebarExpandBtn.setAttribute("aria-hidden", "true");
+    }
+  }
+}
+
 const initialUsers = [
   {
     id: "u-admin-1",
@@ -267,6 +291,7 @@ document.addEventListener("DOMContentLoaded", () => {
 function cacheDomElements() {
   elements.authSection = document.getElementById("authSection");
   elements.dashboard = document.getElementById("dashboard");
+  elements.dashboardShell = document.getElementById("dashboardShell");
   elements.loginForm = document.getElementById("loginForm");
   elements.userSelector = document.getElementById("userSelector");
   elements.loginError = document.getElementById("loginError");
@@ -295,6 +320,11 @@ function cacheDomElements() {
   elements.auxiliarActivityAlert = document.getElementById("auxiliarActivityAlert");
   elements.printReport = document.getElementById("printReport");
   elements.refreshDashboard = document.getElementById("refreshDashboard");
+  elements.sidebarCollapseBtn = document.getElementById("sidebarCollapseBtn");
+  elements.sidebarExpandBtn = document.getElementById("sidebarExpandBtn");
+  if (elements.dashboardShell) {
+    setSidebarCollapsed(false);
+  }
 }
 
 function hideLoader() {
@@ -335,6 +365,22 @@ function attachEventListeners() {
       "click",
       importSoftwareTeachers,
     );
+  }
+  if (elements.sidebarCollapseBtn) {
+    elements.sidebarCollapseBtn.addEventListener("click", () => {
+      setSidebarCollapsed(true);
+      if (elements.sidebarExpandBtn) {
+        elements.sidebarExpandBtn.focus();
+      }
+    });
+  }
+  if (elements.sidebarExpandBtn) {
+    elements.sidebarExpandBtn.addEventListener("click", () => {
+      setSidebarCollapsed(false);
+      if (elements.sidebarCollapseBtn) {
+        elements.sidebarCollapseBtn.focus();
+      }
+    });
   }
 }
 
@@ -399,6 +445,7 @@ function loginUser(user) {
   buildNavigation(user.role);
   renderSidebarUserCard(user);
   renderAllSections();
+  setSidebarCollapsed(false);
   if (elements.loginForm) {
     elements.loginForm.reset();
   }
@@ -423,6 +470,7 @@ function handleLogout() {
   document
     .querySelectorAll("[data-nav-label]")
     .forEach((section) => section.classList.remove("is-targeted"));
+  setSidebarCollapsed(false);
   updateHeaderStats();
   refreshIcons();
 }

--- a/style.css
+++ b/style.css
@@ -56,10 +56,23 @@ a {
   backdrop-filter: blur(18px);
 }
 
-.app-header__inner,
-main {
+.app-header__inner {
   width: min(1090px, 96vw);
   margin: 0 auto;
+}
+
+main {
+  --main-offset-left: clamp(0.75rem, 3vw, 3rem);
+  --main-offset-right: clamp(2rem, 7vw, 6rem);
+  --main-viewport-width: 100vw;
+  --main-max-width: 1180px;
+  width: min(
+    var(--main-max-width),
+    calc(
+      var(--main-viewport-width) - var(--main-offset-left) - var(--main-offset-right)
+    )
+  );
+  margin: 0 var(--main-offset-right) 0 var(--main-offset-left);
 }
 
 .app-header__inner {
@@ -193,9 +206,13 @@ body.dashboard-active main {
   justify-content: flex-start;
 }
 
-body.dashboard-active .app-header__inner,
-body.dashboard-active main {
+body.dashboard-active .app-header__inner {
   width: min(96vw, 1380px);
+}
+
+body.dashboard-active main {
+  --main-viewport-width: 96vw;
+  --main-max-width: 1380px;
 }
 
 body.auth-active main {
@@ -559,6 +576,23 @@ button.primary:hover {
   align-items: stretch;
   height: 100%;
   min-height: 0;
+  transition: grid-template-columns 0.25s ease, gap 0.25s ease;
+}
+
+.dashboard-shell.sidebar-collapsed {
+  grid-template-columns: minmax(0, 0px) minmax(0, 1fr);
+  gap: clamp(1.4rem, 2.5vw, 2rem);
+}
+
+.dashboard-shell.sidebar-collapsed .sidebar {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-28px);
+  pointer-events: none;
+}
+
+.dashboard-shell.sidebar-collapsed .content-area {
+  grid-column: 2 / -1;
 }
 
 .sidebar {
@@ -572,6 +606,60 @@ button.primary:hover {
   gap: 2rem;
   color: white;
   box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.55);
+  transition: opacity 0.25s ease, transform 0.25s ease, visibility 0.25s ease;
+}
+
+.sidebar .sidebar-toggle {
+  align-self: flex-end;
+}
+
+.sidebar-toggle {
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+  border-radius: 14px;
+  padding: 0.6rem 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease,
+    box-shadow 0.2s ease;
+  box-shadow: 0 18px 38px -26px rgba(15, 23, 42, 0.65);
+}
+
+.sidebar-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+.sidebar-toggle:hover {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateX(-2px);
+}
+
+.sidebar-toggle--floating {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  justify-self: flex-start;
+  margin-bottom: 1rem;
+  color: var(--primary);
+  background: rgba(37, 99, 235, 0.12);
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  box-shadow: 0 18px 40px -28px rgba(37, 99, 235, 0.55);
+}
+
+.sidebar-toggle--floating:hover {
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--primary-dark);
+  transform: translateX(0);
+}
+
+.sidebar-toggle--floating[hidden] {
+  display: none !important;
 }
 
 .user-card {
@@ -1215,9 +1303,13 @@ button.small i {
 /* Responsive */
 @media (max-width: 1280px) {
   .app-header__inner,
-  .app-header__meta,
-  main {
+  .app-header__meta {
     width: min(96vw, 1200px);
+  }
+
+  main {
+    --main-max-width: 1200px;
+    --main-offset-right: clamp(1.8rem, 6vw, 4.5rem);
   }
 
   .dashboard-shell {
@@ -1227,9 +1319,13 @@ button.small i {
 
 @media (max-width: 1024px) {
   .app-header__inner,
-  .app-header__meta,
-  main {
+  .app-header__meta {
     width: min(96vw, 960px);
+  }
+
+  main {
+    --main-offset-left: clamp(0.75rem, 4vw, 2.25rem);
+    --main-offset-right: clamp(1rem, 5vw, 3.25rem);
   }
 
   .dashboard-shell {
@@ -1239,6 +1335,18 @@ button.small i {
   .sidebar {
     position: sticky;
     top: 6rem;
+  }
+
+  .dashboard-shell.sidebar-collapsed {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-shell.sidebar-collapsed .content-area {
+    grid-column: 1 / -1;
+  }
+
+  .dashboard-shell.sidebar-collapsed .sidebar {
+    display: none;
   }
 }
 
@@ -1260,6 +1368,11 @@ button.small i {
   .header-tools {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  main {
+    --main-offset-left: clamp(0.6rem, 4vw, 1.5rem);
+    --main-offset-right: clamp(0.75rem, 6vw, 2rem);
   }
 
   header .user-meta {


### PR DESCRIPTION
## Summary
- shift the main dashboard layout further left using responsive CSS variables
- add buttons and styles to hide/show the sidebar, including a floating reopen control
- update dashboard scripts to manage sidebar collapse state and focus behavior

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68d6d281820c8325851a91280ffb9ef5