### PR TITLE
Capture user metadata during bulk imports and sync to Firebase

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,53 @@
+import { initializeApp, getApps, getApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
+import { getFirestore } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+const FALLBACK_CONFIG = {
+  apiKey: "",
+  authDomain: "",
+  projectId: "",
+  storageBucket: "",
+  messagingSenderId: "",
+  appId: "",
+};
+
+let firestoreDb = null;
+
+function resolveConfig() {
+  if (typeof window !== "undefined" && window.firebaseConfig) {
+    return window.firebaseConfig;
+  }
+  return FALLBACK_CONFIG;
+}
+
+export function getFirebaseConfig() {
+  return resolveConfig();
+}
+
+export function getFirestoreDb() {
+  if (firestoreDb) {
+    return firestoreDb;
+  }
+
+  const config = resolveConfig();
+  if (!config || !config.projectId) {
+    console.warn(
+      "Firebase no está configurado. Define window.firebaseConfig con las credenciales de tu proyecto.",
+    );
+    return null;
+  }
+
+  try {
+    const app = getApps().length ? getApp() : initializeApp(config);
+    firestoreDb = getFirestore(app);
+  } catch (error) {
+    console.error("No fue posible inicializar Firebase:", error);
+    return null;
+  }
+
+  return firestoreDb;
+}
+
+export function isFirestoreConfigured() {
+  const config = resolveConfig();
+  return Boolean(config && config.projectId);
+}

--- a/index.html
+++ b/index.html
@@ -454,6 +454,17 @@
       </section>
     </main>
 
+    <!-- Configuración de Firebase -->
+    <script>
+      window.firebaseConfig = window.firebaseConfig || {
+        apiKey: "",
+        authDomain: "",
+        projectId: "",
+        storageBucket: "",
+        messagingSenderId: "",
+        appId: "",
+      };
+    </script>
     <!-- Lógica de la Aplicación -->
     <script src="script.js" type="module"></script>
   </body>


### PR DESCRIPTION
## Summary
- extend user fixtures and UI to track control number, Potro/institutional emails and cellular data for admins, docentes y auxiliares
- add a reusable Firebase helper and update the bulk-import flow to write imported docentes to Firestore with graceful handling when no config is present
- surface the enriched metadata in the selector, sidebar card and admin user table for easier verification after imports

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6d957ad9083259dbbb0eb3f1673f3