### PR TITLE
Add admin-only manual user management controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,147 @@
                     </button>
                     <div id="importTeachersAlert"></div>
                   </div>
+                  <div class="user-management-actions">
+                    <button
+                      class="primary"
+                      type="button"
+                      id="startAddUserBtn"
+                      hidden
+                    >
+                      <i data-lucide="user-plus"></i>
+                      <span>Agregar usuario</span>
+                    </button>
+                  </div>
+                  <form id="userForm" class="user-form" hidden>
+                    <header class="user-form-header">
+                      <h3 id="userFormTitle">Agregar usuario</h3>
+                      <p id="userFormDescription">
+                        Registra un nuevo docente, administrador o auxiliar.
+                      </p>
+                    </header>
+                    <div class="form-grid">
+                      <div class="form-field">
+                        <label for="userName">Nombre completo</label>
+                        <input
+                          id="userName"
+                          name="name"
+                          type="text"
+                          placeholder="Ej. Juan Pérez"
+                          required
+                        />
+                      </div>
+                      <div class="form-field">
+                        <label for="userRole">Rol</label>
+                        <select
+                          id="userRole"
+                          name="role"
+                          data-default="docente"
+                        >
+                          <option value="docente" selected>Docente</option>
+                          <option value="auxiliar">Auxiliar</option>
+                          <option value="administrador">Administrador</option>
+                        </select>
+                      </div>
+                      <div class="form-field">
+                        <label for="userCareer">Carrera</label>
+                        <select
+                          id="userCareer"
+                          name="career"
+                          data-default="software"
+                        >
+                          <option value="software" selected>
+                            Ing. en Software
+                          </option>
+                          <option value="manufactura">
+                            Ing. en Manufactura
+                          </option>
+                          <option value="mecatronica">
+                            Ing. en Mecatrónica
+                          </option>
+                          <option value="global">
+                            General (todas las carreras)
+                          </option>
+                        </select>
+                      </div>
+                      <div class="form-field">
+                        <label for="userId">ID</label>
+                        <input
+                          id="userId"
+                          name="id"
+                          type="text"
+                          placeholder="Ej. u-doc-5"
+                        />
+                      </div>
+                      <div class="form-field">
+                        <label for="userControlNumber">Número de control</label>
+                        <input
+                          id="userControlNumber"
+                          name="controlNumber"
+                          type="text"
+                          placeholder="Ej. D230205"
+                        />
+                      </div>
+                      <div class="form-field">
+                        <label for="userPotroEmail">Correo Potro</label>
+                        <input
+                          id="userPotroEmail"
+                          name="potroEmail"
+                          type="email"
+                          placeholder="nombre.apellido@potros.itson.edu.mx"
+                        />
+                      </div>
+                      <div class="form-field">
+                        <label for="userInstitutionalEmail">
+                          Correo institucional
+                        </label>
+                        <input
+                          id="userInstitutionalEmail"
+                          name="institutionalEmail"
+                          type="email"
+                          placeholder="nombre.apellido@itson.edu.mx"
+                        />
+                      </div>
+                      <div class="form-field">
+                        <label for="userAltEmail">Correo alterno</label>
+                        <input
+                          id="userAltEmail"
+                          name="email"
+                          type="email"
+                          placeholder="correo.personal@dominio.com"
+                        />
+                      </div>
+                      <div class="form-field">
+                        <label for="userPhone">Teléfono</label>
+                        <input
+                          id="userPhone"
+                          name="phone"
+                          type="tel"
+                          placeholder="Ej. (644) 123 4567"
+                        />
+                      </div>
+                    </div>
+                    <label class="form-checkbox">
+                      <input
+                        type="checkbox"
+                        id="userAllowExternalAuth"
+                        name="allowExternalAuth"
+                      />
+                      <span>Permitir inicio de sesión con correo externo</span>
+                    </label>
+                    <p class="form-hint">
+                      Solo el administrador principal puede agregar, editar o
+                      eliminar usuarios.
+                    </p>
+                    <div class="form-actions">
+                      <button type="submit" class="primary" id="userFormSubmit">
+                        Guardar usuario
+                      </button>
+                      <button type="button" class="ghost" id="cancelUserFormBtn">
+                        Cancelar
+                      </button>
+                    </div>
+                  </form>
+                  <div id="userFormAlert"></div>
                   <div id="inviteAlert"></div>
                   <div id="userTableContainer" class="table-responsive"></div>
                 </div>

--- a/style.css
+++ b/style.css
@@ -950,6 +950,120 @@ textarea:focus {
   border: 1px solid rgba(37, 99, 235, 0.12);
 }
 
+.user-management-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1.25rem 0 0.75rem;
+}
+
+.user-form {
+  display: grid;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+  padding: 1.3rem 1.5rem;
+  border-radius: 22px;
+  background: var(--surface);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  box-shadow: 0 25px 60px -58px rgba(15, 23, 42, 0.35);
+}
+
+.user-form-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.user-form-header p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.user-form .form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.form-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.form-checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+}
+
+.form-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.user-form .form-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.table-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.actions-col {
+  width: 1%;
+  white-space: nowrap;
+  text-align: right;
+}
+
+.actions-cell {
+  text-align: right;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  border: none;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.icon-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px -28px rgba(37, 99, 235, 0.65);
+}
+
+.icon-button:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.icon-button.danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--danger);
+}
+
+.icon-button.danger:hover {
+  background: rgba(239, 68, 68, 0.25);
+  box-shadow: 0 18px 40px -28px rgba(239, 68, 68, 0.65);
+}
+
 table th,
 table td {
   padding: 0.9rem 1.1rem;


### PR DESCRIPTION
## Summary
- add a gated user-management toolbar with create form reserved for the primary administrator
- enable editing and deletion from the user table with conflict checks and Firestore persistence hooks
- style the management form and action buttons to match the dashboard design

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6f2af3bc8832589cdbc7b852b8cd1