### PR TITLE
Ajustar ancho del dashboard

### DIFF
--- a/style.css
+++ b/style.css
@@ -198,15 +198,29 @@ main > section {
 
 body.dashboard-active main {
   justify-content: flex-start;
+  --main-viewport-width: 96vw;
+  --main-max-width: 1500px;
+  --main-inline-padding: clamp(1rem, 2.5vw, 2.5rem);
+  max-width: none;
+  width: 100%;
+  margin: 0;
+  padding-inline: var(--main-inline-padding);
 }
 
 body.dashboard-active .app-header__inner {
   width: min(96vw, 1500px);
 }
 
-body.dashboard-active main {
-  --main-viewport-width: 96vw;
-  --main-max-width: 1500px;
+body.dashboard-active .dashboard-shell {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+}
+
+body.dashboard-active .content-area {
+  width: 100%;
+  max-width: none;
+  padding-inline-end: 0;
 }
 
 body.auth-active main {


### PR DESCRIPTION
## Summary
- Expand the dashboard layout so the main container stretches across the viewport when the dashboard is active
- Remove residual max-width and padding constraints on the sidebar and content area to align them with the left edge

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d70d51f5c08325a2b27cde653c80a7