### PR TITLE
Ensure quick access menu opens target sections

### DIFF
--- a/script.js
+++ b/script.js
@@ -1031,6 +1031,17 @@ function buildQuickAccess(role) {
     elements.quickAccess.toggleAttribute("hidden", allowedItems.length === 0);
   }
 
+  const ensureSectionExpanded = (element) => {
+    if (!element) return;
+    if (element instanceof HTMLDetailsElement) {
+      element.open = true;
+    }
+    const parentDetails = element.closest("details");
+    if (parentDetails) {
+      parentDetails.open = true;
+    }
+  };
+
   allowedItems.forEach((item) => {
     const listItem = document.createElement("li");
     const button = document.createElement("button");
@@ -1050,6 +1061,7 @@ function buildQuickAccess(role) {
       if (item.targetId) {
         const target = document.getElementById(item.targetId);
         if (target) {
+          ensureSectionExpanded(target);
           setActiveSection(target);
           target.scrollIntoView({ behavior: "smooth", block: "start" });
           const navLabel = target.dataset.navLabel || "";


### PR DESCRIPTION
## Summary
- ensure quick access actions expand the targeted dashboard section before scrolling
- improve navigation by opening collapsed containers when triggered from the quick access menu

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dabd1a4f248325b742400f38dd689d