### PR TITLE
Revamp Firebase-backed user management

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,6 +448,45 @@
                     </form>
                     <div id="userFormAlert"></div>
                     <div id="inviteAlert"></div>
+                    <div class="user-management-toolbar" id="userManagementToolbar">
+                      <div id="userSyncStatus" class="user-sync-status"></div>
+                      <div id="userSummaryGrid" class="user-summary-grid"></div>
+                      <div class="user-management-filters">
+                        <div class="user-search">
+                          <i data-lucide="search"></i>
+                          <input
+                            type="search"
+                            id="userSearchInput"
+                            placeholder="Buscar por nombre, correo o número"
+                            autocomplete="off"
+                            aria-label="Buscar usuarios"
+                          />
+                        </div>
+                        <select id="userRoleFilter" aria-label="Filtrar por rol">
+                          <option value="all" selected>Todos los roles</option>
+                          <option value="administrador">Administradores</option>
+                          <option value="docente">Docentes</option>
+                          <option value="auxiliar">Auxiliares</option>
+                        </select>
+                        <select id="userCareerFilter" aria-label="Filtrar por carrera">
+                          <option value="all" selected>Todas las carreras</option>
+                          <option value="software">Ing. en Software</option>
+                          <option value="manufactura">Ing. en Manufactura</option>
+                          <option value="mecatronica">Ing. en Mecatrónica</option>
+                          <option value="global">General</option>
+                        </select>
+                        <select id="userAuthFilter" aria-label="Filtrar por tipo de acceso">
+                          <option value="all" selected>Todos los accesos</option>
+                          <option value="allowed">Acceso externo habilitado</option>
+                          <option value="restricted">Solo institucional</option>
+                        </select>
+                        <button type="button" class="ghost small" id="clearUserFiltersBtn">
+                          <i data-lucide="x-circle"></i>
+                          <span>Limpiar filtros</span>
+                        </button>
+                      </div>
+                      <div id="userTableMeta" class="table-meta"></div>
+                    </div>
                     <div id="userTableContainer" class="table-responsive"></div>
                   </div>
                 </div>

--- a/style.css
+++ b/style.css
@@ -1250,6 +1250,219 @@ textarea:focus {
   margin: 1.25rem 0 0.75rem;
 }
 
+.user-management-toolbar {
+  display: grid;
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.user-sync-status {
+  font-size: 0.85rem;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 1.2rem;
+}
+
+.user-sync-status.loading {
+  color: var(--primary);
+}
+
+.user-sync-status.loading::before {
+  content: "";
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid rgba(37, 99, 235, 0.25);
+  border-top-color: var(--primary);
+  animation: spin 0.8s linear infinite;
+}
+
+.user-sync-status.success {
+  color: var(--success);
+}
+
+.user-sync-status.error {
+  color: var(--danger);
+}
+
+.user-sync-status.muted {
+  color: var(--muted);
+}
+
+.user-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 1rem;
+}
+
+.user-summary-card {
+  display: flex;
+  gap: 0.8rem;
+  align-items: flex-start;
+  padding: 1rem 1.2rem;
+  border-radius: 18px;
+  background: var(--surface);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  box-shadow: 0 20px 48px -45px rgba(15, 23, 42, 0.35);
+}
+
+.user-summary-icon {
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 14px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.user-summary-icon i {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.user-summary-content {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.user-summary-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.user-summary-value {
+  font-size: 1.45rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.user-summary-helper {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.user-summary-empty {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.2rem;
+  border-radius: 18px;
+  border: 1px dashed rgba(37, 99, 235, 0.2);
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--muted);
+}
+
+.user-summary-empty i {
+  width: 1.4rem;
+  height: 1.4rem;
+  color: var(--primary);
+}
+
+.user-management-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.user-search {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.85rem;
+  border-radius: 14px;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  background: rgba(255, 255, 255, 0.95);
+  min-width: clamp(220px, 25vw, 320px);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.user-search:focus-within {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+}
+
+.user-search i {
+  width: 1.1rem;
+  height: 1.1rem;
+  color: var(--muted);
+}
+
+.user-search input {
+  border: none;
+  padding: 0;
+  background: transparent;
+  font-size: 0.95rem;
+  width: 100%;
+}
+
+.user-search input:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+.user-management-filters select {
+  min-width: 180px;
+}
+
+button.ghost.small {
+  padding: 0.55rem 0.9rem;
+  font-size: 0.85rem;
+}
+
+button.ghost.small i {
+  width: 1rem;
+  height: 1rem;
+}
+
+.table-meta {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.table-meta.error {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.loading-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.95rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.loading-state::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(37, 99, 235, 0.25);
+  border-top-color: var(--primary);
+  animation: spin 0.8s linear infinite;
+}
+
+.badge.external {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary);
+}
+
+.badge.external.off {
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--muted);
+}
+
 .user-form {
   display: grid;
   gap: 1.25rem;


### PR DESCRIPTION
## Summary
- add a real-time Firestore subscription for user records with sync status feedback and pending login retry handling
- redesign the admin user management area with summary cards, search and filters, and an external access column in the user table
- refresh styling to support the new toolbar, loading states, and access badges for external login policies

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dae0ca0cfc8325bfe68f04c3d23c69