### PR TITLE
Allow primary admin to bypass user document id check

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -60,7 +60,8 @@ service cloud.firestore {
     }
 
     function matchesUserDocumentId(userId, data) {
-      return (data.userId != null && normalizedEmail(data.userId) == userId) ||
+      return isPrimaryAdmin() ||
+        (data.userId != null && normalizedEmail(data.userId) == userId) ||
         (data.potroEmail != null && normalizedEmail(data.potroEmail) == userId) ||
         (data.institutionalEmail != null && normalizedEmail(data.institutionalEmail) == userId) ||
         (data.email != null && normalizedEmail(data.email) == userId) ||


### PR DESCRIPTION
## Summary
- allow the primary admin account to bypass document id matching when writing user records so the sync no longer fails for that email

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68db03e6409c83258f0d9059f9253f50